### PR TITLE
Fix swagger schema by removing unsupported property in parameters

### DIFF
--- a/src/docs/repo.yaml
+++ b/src/docs/repo.yaml
@@ -92,7 +92,6 @@ definitions:
         description: Name of project to search.
         required: false
         type: string
-        examle: alexa
     responses:
       200:
         description: An array of projects


### PR DESCRIPTION
`example` property not supported as `parameters` property.

fixed #24 